### PR TITLE
Merge resolvers

### DIFF
--- a/src/merge_resolvers.js
+++ b/src/merge_resolvers.js
@@ -5,9 +5,15 @@ const mergeResolvers = (resolvers, options) => {
     ...resolvers.map(({ queries }) => queries)
   );
 
-  const mutationResolvers = {};
+  const mutationResolvers = Object.assign(
+    {},
+    ...resolvers.map(({ mutations }) => mutations)
+  );
 
-  const subQueriesResolvers = {};
+  const subQueriesResolvers = Object.assign(
+    {},
+    ...resolvers.map(({ subQueries }) => subQueries)
+  );
 
   return Object.assign(
     {

--- a/test/graphql/resolvers/client_resolver.js
+++ b/test/graphql/resolvers/client_resolver.js
@@ -3,8 +3,15 @@ const queries = {
   client: () => {},
 };
 
-const subQueries = {};
+const mutations = {
+  create_client: () => {},
+  update_client: () => {},
+};
 
-const mutations = {};
+const subQueries = {
+  Client: {
+    products: () => {},
+  }
+};
 
-export { queries, subQueries, mutations };
+export { queries, mutations, subQueries };

--- a/test/graphql/resolvers/product_resolver.js
+++ b/test/graphql/resolvers/product_resolver.js
@@ -3,8 +3,15 @@ const queries = {
   product: () => {},
 };
 
-const subQueries = {};
+const mutations = {
+  create_product: () => {},
+  update_product: () => {},
+};
 
-const mutations = {};
+const subQueries = {
+  Product: {
+    clients: () => {},
+  }
+};
 
-export { queries, subQueries, mutations };
+export { queries, mutations, subQueries };

--- a/test/graphql/types/product_type.js
+++ b/test/graphql/types/product_type.js
@@ -3,6 +3,7 @@ const type = `
     id: ID!
     description: String
     price: Int
+    clients: [Client]
   }
 `;
 

--- a/test/merge_resolvers_test.js
+++ b/test/merge_resolvers_test.js
@@ -13,12 +13,33 @@ describe('mergeResolvers', () => {
       const resolvers = [clientResolver, productResolver];
       const mergedResolvers = mergeResolvers(resolvers);
 
-      assert.isDefined(mergedResolvers.Query.clients, 'Merged resolvers is missing Query Resolvers');
-      assert.isDefined(mergedResolvers.Query.client, 'Merged resolvers is missing Query Resolvers');
-      assert.isDefined(mergedResolvers.Query.products, 'Merged resolvers is missing Query Resolvers');
-      assert.isDefined(mergedResolvers.Query.product, 'Merged resolvers is missing Query Resolvers');
+      assert.isDefined(mergedResolvers.Query.clients, 'Merged resolvers is missing clients resolver');
+      assert.isDefined(mergedResolvers.Query.client, 'Merged resolvers is missing client resolver');
+      assert.isDefined(mergedResolvers.Query.products, 'Merged resolvers is missing products resolver');
+      assert.isDefined(mergedResolvers.Query.product, 'Merged resolvers is missing product resolver');
 
     });
 
+    it('merges all mutation resolvers', async () => {
+
+      const resolvers = [clientResolver, productResolver];
+      const mergedResolvers = mergeResolvers(resolvers);
+
+      assert.isDefined(mergedResolvers.Mutation.create_client, 'Merged resolvers is missing create_client resolver');
+      assert.isDefined(mergedResolvers.Mutation.update_client, 'Merged resolvers is missing update_client resolver');
+      assert.isDefined(mergedResolvers.Mutation.create_product, 'Merged resolvers is missing create_product resolver');
+      assert.isDefined(mergedResolvers.Mutation.update_product, 'Merged resolvers is missing update_product resolver');
+
+    });
+
+    it('merges all subQuery resolvers', async () => {
+
+      const resolvers = [clientResolver, productResolver];
+      const mergedResolvers = mergeResolvers(resolvers);
+
+      assert.isDefined(mergedResolvers.Client.products, 'Merged resolvers is missing Client.products resolver');
+      assert.isDefined(mergedResolvers.Product.clients, 'Merged resolvers is missing Product.clients resolver');
+
+    });
   });
 });

--- a/test/merge_types_test.js
+++ b/test/merge_types_test.js
@@ -92,6 +92,7 @@ describe('mergeTypes', () => {
           id: ID!
           description: String
           price: Int
+          clients: [Client]
         }
       `.replace(/ |\n/g,'');
 


### PR DESCRIPTION
@rdickert  @tsemana 
PR implementing `mergeResolvers()` function. Just like `mergeTypes()` it is not allowing any options.

We need to think about adding some validations (Missing resolvers, conflicts, etc), but that can wait until we finish the basic functionality.

😄 