### PR TITLE
Bumping version to 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.5.4]
+### Fixed
+- added fix for merging interface and scalar [PR #157](https://github.com/okgrow/merge-graphql-schemas/pull/157) by [@iamrommel](https://github.com/iamrommel)
+
+### Changed
+- Package updates [PR #162](https://github.com/okgrow/merge-graphql-schemas/pull/162) by [@cfnelson](https://github.com/cfnelson)
+  - Upgraded dependencies to:
+    - "deepmerge": "^2.1.1",
+    - "glob": "^7.1.3",
+  - Upgraded devDependencies - Refer to PR
+
 ## [1.5.3]
 ### Fixed
 - Support comments for enum values in [PR #147](https://github.com/okgrow/merge-graphql-schemas/pull/147) by [@lacolaco](https://github.com/lacolaco)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "merge-graphql-schemas",
   "author": "OK GROW!",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A utility library to facilitate merging of modularized GraphQL schemas and resolver objects.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## [1.5.4]
### Fixed
- added fix for merging interface and scalar [PR #157](https://github.com/okgrow/merge-graphql-schemas/pull/157) by [@iamrommel](https://github.com/iamrommel)

### Changed
- Package updates [PR #162](https://github.com/okgrow/merge-graphql-schemas/pull/162) by [@cfnelson](https://github.com/cfnelson)
  - Upgraded dependencies to:
    - "deepmerge": "^2.1.1",
    - "glob": "^7.1.3",
  - Upgraded devDependencies - Refer to PR