### PR TITLE
More accurate Typescript definitions.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,7 @@
-import { DocumentNode, Source } from 'graphql';
+import { DocumentNode } from 'graphql';
 
 export function mergeTypes(
-  types: Array<string | Source | DocumentNode>,
+  types: Array<string | DocumentNode>,
   options?: { all: boolean }
 ): string;
 
@@ -14,4 +14,4 @@ export function fileLoader(
     extensions?: string[];
     globOptions?: object;
   }
-): Array<string | any>;
+): string[];


### PR DESCRIPTION
More accurate type definitions based on additional analysis of the code.   Addresses issues already resolved by #169, #170, #172 

Tracing all of the existing Typescript definitions through `fileLoader`, this should be correct:

```
export function fileLoader(
  path: string,
  options?: {
    recursive?: boolean;
    extensions?: string[];
    globOptions?: object;
  }
): string[];
```

The code takes a string `path`, a set of `options` and returns an array of `string`.

So, what about `mergeTypes`?  It actually will only correctly accept:

```
export function mergeTypes(
  types: Array<string | DocumentNode>,
  options?: { all: boolean }
): string;
```

It expects `types` to be an array of either `string` or `DocumentNode`.   If the element is a `string` the code passes it off to graphql.parse:

https://github.com/okgrow/merge-graphql-schemas/blob/b0d0ae412e0f16cc5de5c2db10532d32d2b60ed9/src/merge_types.js#L153-L155

Otherwise, it seems to make the assumption that the object is already a `DocumentNode` or, more correctly, an object that has a `definitions` property:

https://github.com/okgrow/merge-graphql-schemas/blob/b0d0ae412e0f16cc5de5c2db10532d32d2b60ed9/src/merge_types.js#L158

Would appreciate if @koenpunt and @yoloOnTheBattlefield would drop this PRs `typings/index.d.ts` into their codebases and re-compile with them.