### PR TITLE
Fix error when newDef is undefined

### DIFF
--- a/src/merge_types.js
+++ b/src/merge_types.js
@@ -156,7 +156,7 @@ const mergeTypes = (types, options = { all: false }) => {
       return type;
     })
     .map(ast => ast.definitions)
-    .reduce((defs, newDef) => [...defs, ...newDef], []);
+    .reduce((defs, newDef = []) => [...defs, ...newDef], []);
 
   const mergedDefs = _makeMergedDefinitions(allDefs, options.all);
   const rest = _addCommentsToAST(_makeRestDefinitions(allDefs, options.all), false)

--- a/test/complex.test.js
+++ b/test/complex.test.js
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+import fileLoader from '../src/file_loader';
+import mergeTypes from '../src/merge_types';
+
+const normalizeWhitespace = str => str.replace(/\s+/g, ' ').trim();
+
+describe('when load types based on entity structure', () => {
+  it('will selected all scriptc by fileLoader', () => {
+    const typesPath = path.join(__dirname, 'graphql/type_with_other_scripts')
+    const loadedTypesWithOtherLogic = fileLoader(typesPath, { recursive: true });
+    const loadedTypes = fileLoader(typesPath, { recursive: true, extensions: ['.gql'] });
+
+    expect(loadedTypes.length).not.toEqual(loadedTypesWithOtherLogic.length)
+  })
+
+  it('should merge successfully parsed type', () => {
+    const typesPath = path.join(__dirname, 'graphql/type_with_other_scripts')
+    const loadedTypes = fileLoader(typesPath, { recursive: true });
+    const mergedTypes = mergeTypes(loadedTypes, { all: true })
+
+    const expectedSchemaType = normalizeWhitespace(`
+      type Query {
+        groot: Groot
+      }
+
+      type Groot {
+        id: ID!
+        status: String
+      }
+    `)
+    const schema = normalizeWhitespace(mergedTypes);
+
+    expect(schema).toContain(expectedSchemaType);
+  });
+})

--- a/test/file_loader.test.js
+++ b/test/file_loader.test.js
@@ -13,6 +13,7 @@ import vendorResolver from './graphql/resolvers/vendor_resolver';
 
 const rawType = fs.readFileSync(`${__dirname}/graphql/types/raw_type.graphqls`).toString();
 const raw2Type = fs.readFileSync(`${__dirname}/graphql/types/client/raw2_type.gql`).toString();
+const raw3Type = fs.readFileSync(`${__dirname}/graphql/type_with_other_scripts/groot/groot.gql`).toString();
 
 describe('fileLoader', () => {
   it('loads all files from specified folder', () => {
@@ -74,6 +75,7 @@ describe('fileLoader', () => {
 
   it('loads all files from glob pattern of ext .graphqls or .gql', () => {
     const types = [
+      raw3Type,
       raw2Type,
       rawType,
     ];

--- a/test/graphql/type_with_other_scripts/groot/groot.gql
+++ b/test/graphql/type_with_other_scripts/groot/groot.gql
@@ -1,0 +1,8 @@
+type Query {
+  groot: Groot
+}
+
+type Groot {
+  id: ID!
+  status: String
+}

--- a/test/graphql/type_with_other_scripts/groot/groot.resolvers.js
+++ b/test/graphql/type_with_other_scripts/groot/groot.resolvers.js
@@ -1,0 +1,6 @@
+export default {
+  Query: {
+    // return groot with business logic
+    groot: () => null
+  }
+}

--- a/test/graphql/type_with_other_scripts/utils.js
+++ b/test/graphql/type_with_other_scripts/utils.js
@@ -1,0 +1,1 @@
+export default function utilFunctionForResolver() {}


### PR DESCRIPTION
~~It's more clear solution of #174.~~
solve issue #133

> Sorry for wrong information. It's not solution of #174 😓

## Error Message by this problem
"Cannot convert undefined or null to object"

## Issue

Let's define the problem clearly. Let's say developer have the following folder structure.

```text
# directory structure
entity/
├── index.ts
├── review
│   ├── review.graphql
│   └── review.resolver.ts
└── user
    ├── user.graphql
    └── user.resolver.ts
```

If developer use `fileLoader` like this, `ts` file will be included in `typesArray`

```ts
// entity/index.ts
import * as path from "path"
import { fileLoader, mergeTypes, mergeResolvers } from "merge-graphql-schemas"

// merge all types in child directories
const typesPath = path.join(__dirname, "./")
const typesArray = fileLoader(typesPath, { recursive: true })
const typeDefs = mergeTypes(typesArray, { all: true })

// merge all resolvers in child directories
const resolversPath = path.join(__dirname, "/**/*.resolver.*")
const resolversArray = fileLoader(resolversPath)
const resolvers = mergeResolvers(resolversArray)

export {
    typeDefs,
    resolvers
}
```

## Solution 1
First simple solution is to guide developer to use `extension` options to include only `graphql` files. However, it's not easy to find quickly.

```ts
const typesArray = fileLoader(typesPath, { recursive: true, extensions: [".graphql"] })
```

## Solution 2
It's my suggestions. just put in default value of `newDef`

Only types are reduced through [this code](https://github.com/okgrow/merge-graphql-schemas/blob/master/src/merge_types.js#L158), but there are `undefined` possibility of `newDef`.
So let's add the defaults value. It will solve the problem 😃 